### PR TITLE
Fixed a bug in Sidebar Metabox Html. 

### DIFF
--- a/inc/metaboxes.php
+++ b/inc/metaboxes.php
@@ -167,23 +167,23 @@ function yith_proteo_sidebar_position_html( $post ) {
 	<select name="sidebar_position" id="sidebar_position"
 			class="components-text-control__input">
 		<option
-			value="<?php esc_attr_e( 'inherit', 'yith-proteo' ); ?>" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'inherit' ) ? 'selected' : ''; ?>>
+			value="inherit" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'inherit' ) ? 'selected' : ''; ?>>
 			<?php esc_html_e( 'inherit', 'yith-proteo' ); ?>
 		</option>
 		<option
-			value="<?php esc_attr_e( 'no-sidebar', 'yith-proteo' ); ?>" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'no-sidebar' ) ? 'selected' : ''; ?>>
+			value="no-sidebar" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'no-sidebar' ) ? 'selected' : ''; ?>>
 			<?php esc_html_e( 'no-sidebar', 'yith-proteo' ); ?>
 		</option>
 		<option
-			value="<?php esc_attr_e( 'left', 'yith-proteo' ); ?>" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'left' ) ? 'selected' : ''; ?>>
+			value="left" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'left' ) ? 'selected' : ''; ?>>
 			<?php esc_html_e( 'left', 'yith-proteo' ); ?>
 		</option>
 		<option
-			value="<?php esc_attr_e( 'right', 'yith-proteo' ); ?>" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'right' ) ? 'selected' : ''; ?>>
+			value="right" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'right' ) ? 'selected' : ''; ?>>
 			<?php esc_html_e( 'right', 'yith-proteo' ); ?>
 		</option>
 		<option
-			value="<?php esc_attr_e( 'bottom', 'yith-proteo' ); ?>" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'bottom' ) ? 'selected' : ''; ?>>
+			value="bottom" <?php echo ( yith_proteo_sidebar_get_meta( 'sidebar_position' ) === 'bottom' ) ? 'selected' : ''; ?>>
 			<?php esc_html_e( 'bottom', 'yith-proteo' ); ?>
 		</option>
 	</select>


### PR DESCRIPTION
Sidebar position values where being translated. The translated values are then saved in the database which causes any other function comparing the result of `yith_proteo_sidebar_get_meta( 'sidebar_position' )` with the stock values of "inherit", "no-sidebar","left","right","bottom" to fail (such as yith_proteo_get_sidebar_position() ).

This caused sidebars to appear on product pages even though 'inherit' was selected in their settings and 'no-sidebar' was selected as the default.