### PR TITLE
Sass variable mixin

### DIFF
--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -26,5 +26,5 @@
 // Column width with margin
 @mixin column-width($numberColumns: 3) {
 	//width: map-get( $columns, $numberColumns ) - ( ( $columns__margin * ( $numberColumns - 1 ) ) / $numberColumns );
-	width: calc(100% / $numberColumns);
+	width: calc(100% / #{$numberColumns});
 }


### PR DESCRIPTION
This variable wasn't compiled in css, this fix the issue with the latest SASS versions.